### PR TITLE
refactor: name bam2fastq process for nf-core schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - bwa/index
 - bwa/mem
   - also runs samtools sort & outputs index in bai format. (#12)
-- custom/bam_to_fastq (#14)
+- custom/bam2fastq (#14,#22)
 - cutadapt (#11)
 - khmer/uniquekmers (#7)
 - picard/samtofastq (#21)

--- a/modules/CCBR/custom/bam2fastq/main.nf
+++ b/modules/CCBR/custom/bam2fastq/main.nf
@@ -1,4 +1,4 @@
-process BAM2FASTQ {
+process CUSTOM_BAM2FASTQ {
     tag { meta.id }
     label 'process_single'
     container "${ meta.single_end ? 'nciccbr/ccbr_ubuntu_base_20.04:v5' : 'nciccbr/ccbr_picard_2.27.5:v1' }"

--- a/modules/CCBR/custom/bam2fastq/meta.yml
+++ b/modules/CCBR/custom/bam2fastq/meta.yml
@@ -1,4 +1,4 @@
-name: bam2fastq
+name: custom_bam2fastq
 description: |
   The module converts a BAM file to FASTQ format.
   It uses samtools bam2fq if reads are single end,

--- a/tests/modules/CCBR/custom/bam2fastq/main.nf
+++ b/tests/modules/CCBR/custom/bam2fastq/main.nf
@@ -4,7 +4,7 @@ nextflow.enable.dsl = 2
 
 include { BWA_INDEX      } from '../../../../../modules/CCBR/bwa/index/main.nf'
 include { BWA_MEM        } from '../../../../../modules/CCBR/bwa/mem/main.nf'
-include { BAM2FASTQ   } from '../../../../../modules/CCBR/custom/bam2fastq/main.nf'
+include { CUSTOM_BAM2FASTQ   } from '../../../../../modules/CCBR/custom/bam2fastq/main.nf'
 
 //
 // Test with single-end data
@@ -23,7 +23,7 @@ workflow test_bam2fastq_single {
 
     BWA_INDEX ( fasta )
     BWA_MEM ( input, BWA_INDEX.out.index )
-    BAM2FASTQ( BWA_MEM.out.bam )
+    CUSTOM_BAM2FASTQ( BWA_MEM.out.bam )
 }
 
 //
@@ -44,5 +44,5 @@ workflow test_bam2fastq_paired {
 
     BWA_INDEX ( fasta )
     BWA_MEM ( input, BWA_INDEX.out.index )
-    BAM2FASTQ( BWA_MEM.out.bam )
+    CUSTOM_BAM2FASTQ( BWA_MEM.out.bam )
 }

--- a/tests/modules/CCBR/custom/bam2fastq/test.yml
+++ b/tests/modules/CCBR/custom/bam2fastq/test.yml
@@ -4,8 +4,8 @@
     - custom/bam2fastq
     - custom
   files:
-    - path: output/bam2fastq/test.R1.fastq.gz
-    - path: output/bwa/versions.yml
+    - path: output/custom/test.R1.fastq.gz
+    - path: output/custom/versions.yml
 
 - name: custom bam2fastq test_bam2fastq_paired
   command: nextflow run ./tests/modules/CCBR/custom/bam2fastq -entry test_bam2fastq_paired -c ./tests/config/nextflow.config
@@ -13,7 +13,7 @@
     - custom/bam2fastq
     - custom
   files:
-    - path: output/bam2fastq/test.R1.fastq.gz
-    - path: output/bam2fastq/test.R2.fastq.gz
-    - path: output/bam2fastq/test.unpaired.fastq.gz
-    - path: output/bwa/versions.yml
+    - path: output/custom/test.R1.fastq.gz
+    - path: output/custom/test.R2.fastq.gz
+    - path: output/custom/test.unpaired.fastq.gz
+    - path: output/custom/versions.yml


### PR DESCRIPTION
## Changes

renamed bam2fastq process custom_bam2fastq. otherwise subworkflows that use them have lint failures.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
