### PR TITLE
fix: use filter aligned output for samToFastq input

### DIFF
--- a/subworkflows/CCBR/filter_blacklist/main.nf
+++ b/subworkflows/CCBR/filter_blacklist/main.nf
@@ -14,7 +14,7 @@ workflow FILTER_BLACKLIST {
 
         BWA_MEM ( ch_fastq_input, ch_blacklist_index )
         SAMTOOLS_FILTERALIGNED( BWA_MEM.out.bam )
-        PICARD_SAMTOFASTQ( BWA_MEM.out.bam )
+        PICARD_SAMTOFASTQ( SAMTOOLS_FILTERALIGNED.out.bam )
 
         ch_versions = ch_versions.mix(
             BWA_MEM.out.versions,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
+biopython
 pysam>=0.22.0
 pytest-workflow

--- a/tests/subworkflows/CCBR/filter_blacklist/main.nf
+++ b/tests/subworkflows/CCBR/filter_blacklist/main.nf
@@ -10,9 +10,11 @@ workflow test_filter_blacklist_single {
     input = [ [ id:'test', single_end:true ], // meta map
                file(params.test_data['test_1_fastq_gz'], checkIfExists: true)
     ]
+    blacklist_file = file(params.test_data['test_1_subset_fastq_gz'], checkIfExists: true)
+    blacklist_file.copyTo(file("output/blacklist.fastq.gz"))
     blacklist_reads = [
             [ id:'test', single_end:true ], // meta map
-            file(params.test_data['test_1_subset_fastq_gz'], checkIfExists: true)
+            blacklist_file
     ]
     BWA_INDEX(blacklist_reads)
     FILTER_BLACKLIST(input, BWA_INDEX.out.index)
@@ -23,9 +25,11 @@ workflow test_filter_blacklist_paired {
               [ file(params.test_data['test_1_fastq_gz'], checkIfExists: true),
                 file(params.test_data['test_2_fastq_gz'], checkIfExists: true) ]
     ]
+    blacklist_file = file(params.test_data['test_1_subset_fastq_gz'], checkIfExists: true)
+    blacklist_file.copyTo(file("output/blacklist.fastq.gz"))
     blacklist_reads = [
-              [ id:'test', single_end:false ], // meta map
-              file(params.test_data['test_1_subset_fastq_gz'], checkIfExists: true)
+            [ id:'test', single_end:true ], // meta map
+            blacklist_file
     ]
     BWA_INDEX(blacklist_reads)
     FILTER_BLACKLIST(input, BWA_INDEX.out.index)

--- a/tests/subworkflows/CCBR/filter_blacklist/test_filter_blacklist.py
+++ b/tests/subworkflows/CCBR/filter_blacklist/test_filter_blacklist.py
@@ -1,3 +1,5 @@
+import Bio
+import Bio.SeqIO
 import gzip
 import pathlib
 import pytest
@@ -11,3 +13,31 @@ def test_unpaired_is_empty(workflow_dir):
     with gzip.open(unpaired_fastq, "rt") as infile:
         lines = infile.readlines()
     assert len(lines) == 0
+
+
+def get_record_ids(fastq_path):
+    with gzip.open(fastq_path, "rt") as file_handle:
+        ids = {rec.id.split("/")[0] for rec in Bio.SeqIO.parse(file_handle, "fastq")}
+    return ids
+
+
+def jaccard(set_1, set_2):
+    return len(set_1.intersection(set_2)) / len(set_1.union(set_2))
+
+
+@pytest.mark.workflow("filter_blacklist test_filter_blacklist_paired")
+def test_blacklist_filtered_out(workflow_dir):
+    blacklist = get_record_ids(
+        pathlib.Path(workflow_dir, "output", "blacklist.fastq.gz")
+    )
+    out_1 = get_record_ids(
+        pathlib.Path(workflow_dir, "output", "picard", "test_1.fastq.gz")
+    )
+    out_2 = get_record_ids(
+        pathlib.Path(workflow_dir, "output", "picard", "test_2.fastq.gz")
+    )
+    assert (
+        not blacklist.intersection(out_1)
+        and not blacklist.intersection(out_2)
+        and jaccard(out_1, out_2) == 1
+    )


### PR DESCRIPTION
## Changes

previously it was just passing bwa mem to samtofastq instead of using the filtered output

## Issues

<!--
Reference any issues related to this PR.
If this PR fixes any issues, [use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
