### PR TITLE
feat: collapse peak p-values in bedtools/merge, reformat with new process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ work/
 /.quarto/
 .Rproj.user
 *.Rproj
+.Rbuildignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,18 @@
 
 - bedops/bedmap (#37)
 - bedtools/map (#37)
-- bedtools/merge (#37)
+- bedtools/merge (#37,#39)
 - bedtools/sort (#37)
 - cat/cat (#37)
 - cat/fastq (#37)
 - custom/combinepeakcounts (#37)
 - custom/consensuspeaks (#37)
-- custom/normalizepeaks (#37)
+- custom/formatmergedbed (#39)
+- custom/normalizepeaks (#37,#39)
 
 ### New subworkflows
 
-- consensus_peaks (#37)
+- consensus_peaks (#37,#39)
 
 ## nf-modules 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - custom/consensuspeaks (#37)
 - custom/formatmergedbed (#39)
 - custom/normalizepeaks (#37,#39)
+- sort/bed (#39)
 
 ### New subworkflows
 

--- a/modules/CCBR/bedtools/merge/main.nf
+++ b/modules/CCBR/bedtools/merge/main.nf
@@ -16,8 +16,7 @@ process BEDTOOLS_MERGE {
     task.ext.when == null || task.ext.when
 
     script:
-    def prefix = task.ext.prefix ?: "${meta.id}.merged"
-    if ("$bed" == "${prefix}.bed") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    def prefix = "${bed.baseName}.merged"
     """
     bedtools \\
         merge \\
@@ -32,7 +31,7 @@ process BEDTOOLS_MERGE {
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}.merged"
+    def prefix = "${bed.baseName}.merged"
     """
     touch ${prefix}.bed
 

--- a/modules/CCBR/bedtools/merge/main.nf
+++ b/modules/CCBR/bedtools/merge/main.nf
@@ -6,6 +6,7 @@ process BEDTOOLS_MERGE {
 
     input:
     tuple val(meta), path(bed)
+    val(args)
 
     output:
     tuple val(meta), path('*.bed'), emit: bed
@@ -15,7 +16,6 @@ process BEDTOOLS_MERGE {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}.merged"
     if ("$bed" == "${prefix}.bed") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     """

--- a/modules/CCBR/bedtools/merge/meta.yml
+++ b/modules/CCBR/bedtools/merge/meta.yml
@@ -21,6 +21,9 @@ input:
       type: file
       description: Input BED file
       pattern: "*.{bed}"
+  - args:
+      type: string
+      description: optional arguments for bedtools merge
 output:
   - meta:
       type: map

--- a/modules/CCBR/bedtools/sort/main.nf
+++ b/modules/CCBR/bedtools/sort/main.nf
@@ -17,7 +17,7 @@ process BEDTOOLS_SORT {
 
     script:
     def args       = task.ext.args   ?: ''
-    def prefix     = task.ext.prefix ?: "${meta.id}.sorted"
+    def prefix     = task.ext.prefix ?: "${intervals.baseName}.sorted"
     def genome_cmd = genome_file     ?  "-g $genome_file" : ""
     extension      = task.ext.suffix ?: intervals.extension
     if ("$intervals" == "${prefix}.${extension}") {

--- a/modules/CCBR/cat/cat/main.nf
+++ b/modules/CCBR/cat/cat/main.nf
@@ -35,7 +35,7 @@ process CAT_CAT {
     """
     $command1 \\
         $args \\
-        ${file_list.join(' ')} \\
+        ${file_list.sort({ a, b -> a.baseName <=> b.baseName }).join(' ')} \\
         $command2 \\
         > ${prefix}
 

--- a/modules/CCBR/cat/cat/main.nf
+++ b/modules/CCBR/cat/cat/main.nf
@@ -17,7 +17,7 @@ process CAT_CAT {
     script:
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
-    def file_list = files_in.collect { it.toString() }
+    def file_list = files_in.sort({ a, b -> a.baseName <=> b.baseName }).collect{ it.toString() }
 
     // | input     | output     | command1 | command2 |
     // |-----------|------------|----------|----------|
@@ -35,7 +35,7 @@ process CAT_CAT {
     """
     $command1 \\
         $args \\
-        ${file_list.sort({ a, b -> a.baseName <=> b.baseName }).join(' ')} \\
+        ${file_list.join(' ')} \\
         $command2 \\
         > ${prefix}
 

--- a/modules/CCBR/custom/combinepeakcounts/main.nf
+++ b/modules/CCBR/custom/combinepeakcounts/main.nf
@@ -24,9 +24,10 @@ process CUSTOM_COMBINEPEAKCOUNTS {
     template 'combine_peaks.R'
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
+    outfile = "${prefix}.consensus.bed"
     """
-    touch ${prefix}.consensus.bed
+    touch ${outfile}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/CCBR/custom/combinepeakcounts/templates/combine_peaks.R
+++ b/modules/CCBR/custom/combinepeakcounts/templates/combine_peaks.R
@@ -55,20 +55,4 @@ read_peaks <- function(peak_file) {
   return(peaks)
 }
 
-join_counts <- function(versionfile = "versions.yml",
-                        countfile = "${count}",
-                        peakfile = "${peaks}",
-                        outfile = "${outfile}") {
-  write_lines(get_version(), versionfile)
-  count_dat <- read_peaks(countfile)
-  peak_dat <- read_peaks(peakfile) %>%
-    mutate(peakID = glue("{chrom}:{start}-{end}")) %>%
-    normalize() %>%
-    select(peakID, pvalue, qvalue)
-  count_dat %>%
-    select(-c(pvalue, qvalue)) %>%
-    left_join(peak_dat, by = "peakID") %>%
-    write_tsv(outfile, col_names = FALSE)
-}
-
 main()

--- a/modules/CCBR/custom/formatmergedbed/main.nf
+++ b/modules/CCBR/custom/formatmergedbed/main.nf
@@ -1,0 +1,30 @@
+process CUSTOM_FORMATMERGEDBED {
+    tag { meta.id }
+    label 'process_medium'
+
+    container 'nciccbr/consensus_peaks:v1.1'
+
+    input:
+    tuple val(meta), path(merged_bed)
+
+    output:
+    tuple val(meta), path("*.bed"), emit: bed
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    outfile = "${merged_bed.baseName}.consensus.bed"
+    template 'format_merged_bed.R'
+
+    stub:
+    """
+    touch ${merged_bed.baseName}.consensus.bed
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        : \$(echo \$(R --version | grep 'R version' | sed 's/R version //; s/ (.*//'))
+    END_VERSIONS
+    """
+}

--- a/modules/CCBR/custom/formatmergedbed/meta.yml
+++ b/modules/CCBR/custom/formatmergedbed/meta.yml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
+name: "custom_formatmergedbed"
+description: |
+  Reformat consensus peaks from bedtools merge.
+  Used in the consensus_peaks subworkflow.
+keywords:
+  - chipseq
+  - peaks
+  - consensus
+  - bedtools
+tools:
+  - "R":
+      description: "R is a free software environment for statistical computing and graphics"
+      homepage: "https://www.r-project.org/"
+      licence: ["GPL-3"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+  - merged_bed:
+      type: file
+      description: |
+        Merged output file from calling
+        `bedtools merge -c 1,5,6,7,8,9 -o count,collapse,collapse,collapse,collapse,collapse`
+        on a concatenated & sorted peak file
+      pattern: "*.bed"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+  - bed:
+      type: file
+      description: |
+        A narrow peak bed file with the best p-value for each consensus peak
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@kelly-sovacool"
+maintainers:
+  - "@kelly-sovacool"

--- a/modules/CCBR/custom/formatmergedbed/templates/format_merged_bed.R
+++ b/modules/CCBR/custom/formatmergedbed/templates/format_merged_bed.R
@@ -1,0 +1,95 @@
+#!/usr/bin/env Rscript
+library(dplyr)
+library(glue)
+library(purrr)
+library(stringr)
+library(readr)
+library(tidyr)
+
+main <- function(version_file = "versions.yml",
+                 merged_file = "${merged_bed}",
+                 out_file = "${outfile}",
+                 n_cores = as.integer("${task.cpus}"),
+                 min_count = 1) {
+  doFuture::registerDoFuture()
+  future::plan(future::multicore, workers = n_cores)
+  write_version(version_file)
+  merged_dat <- read_tsv(merged_file,
+    col_names = FALSE,
+    col_types = "ciiiccccc"
+  )
+  if (nrow(merged_dat) == 0) {
+    stop("The merged bed file is empty")
+  }
+  colnames(merged_dat) <- c(
+    "chrom", "start", "end",
+    "counts", "score_cat", "strand_cat",
+    "signal_cat", "pvalue_cat", "qvalue_cat"
+  )
+  merged_dat %>%
+    filter(counts >= min_count) %>%
+    future.apply::future_apply(1, select_best_peak) %>%
+    bind_rows() %>%
+    select(
+      "chrom",
+      "start",
+      "end",
+      "peakID",
+      "score",
+      "strand",
+      "signal",
+      "pvalue",
+      "qvalue"
+    ) %>%
+    write_tsv(out_file, col_names = FALSE)
+}
+
+select_best_peak <- function(dat_row) {
+  return(
+    dat_row %>%
+      vec_to_df() %>%
+      pivot_collapsed_columns() %>%
+      slice_max(pvalue)
+  )
+}
+
+vec_to_df <- function(vec) {
+  vec %>%
+    as.list() %>%
+    as_tibble()
+}
+
+pivot_collapsed_columns <- function(dat_row) {
+  row_pivot <- dat_row %>%
+    select(ends_with("_cat")) %>%
+    t() %>%
+    as.data.frame()
+  long_row <- row_pivot %>%
+    mutate(names = rownames(row_pivot)) %>%
+    separate_wider_delim(V1, delim = ",", names_sep = "_") %>%
+    mutate(names = str_replace(names, "_cat", "")) %>%
+    pivot_longer(starts_with("V1")) %>%
+    pivot_wider(names_from = names, values_from = value) %>%
+    select(-name)
+  return(
+    dat_row %>%
+      select(-ends_with("cat")) %>%
+      bind_cols(long_row) %>%
+      mutate(across(c("start", "end", "counts"), as.integer)) %>%
+      mutate(peakID = glue("{chrom}:{start}-{end}")) %>%
+      mutate(across(c("score", "signal", "pvalue", "qvalue"), as.numeric))
+  )
+}
+
+write_version <- function(version_file) {
+  write_lines(get_version(), version_file)
+}
+
+get_version <- function() {
+  return(paste0(R.version[["major"]], ".", R.version[["minor"]]))
+}
+
+
+main("versions.yml", "${merged_bed}", "${outfile}",
+  n_cores = as.integer("${task.cpus}")
+)

--- a/modules/CCBR/custom/normalizepeaks/main.nf
+++ b/modules/CCBR/custom/normalizepeaks/main.nf
@@ -19,12 +19,12 @@ process CUSTOM_NORMALIZEPEAKS {
 
     script:
     prefix = task.ext.prefix ?: "${meta.id}"
-    outfile = "${peak.baseName}.norm.bed"
+    outfile = "${peak}.norm.bed"
     template 'normalize_peaks.R'
 
     stub:
     """
-    touch ${peak.baseName}.norm.bed
+    touch ${peak}.norm.bed
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/CCBR/custom/normalizepeaks/main.nf
+++ b/modules/CCBR/custom/normalizepeaks/main.nf
@@ -8,7 +8,7 @@ process CUSTOM_NORMALIZEPEAKS {
     container 'nciccbr/spacesavers2:0.1.1'
 
     input:
-    tuple val(meta), path(count), path(peaks)
+    tuple val(meta), path(peak)
 
     output:
     tuple val(meta), path("*norm.bed"), emit: bed
@@ -19,12 +19,12 @@ process CUSTOM_NORMALIZEPEAKS {
 
     script:
     prefix = task.ext.prefix ?: "${meta.id}"
-    outfile = "${count.baseName}.norm.bed"
+    outfile = "${peak.baseName}.norm.bed"
     template 'normalize_peaks.R'
 
     stub:
     """
-    touch ${count.baseName}.norm.bed
+    touch ${peak.baseName}.norm.bed
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/CCBR/custom/normalizepeaks/templates/normalize_peaks.R
+++ b/modules/CCBR/custom/normalizepeaks/templates/normalize_peaks.R
@@ -49,7 +49,7 @@ normalize <- function(peak_dat, norm_method = corces) {
         pvalue_norm = norm_method(pvalue),
         qvalue_norm = 10^(-pvalue_norm) %>% p.adjust(method = "BH") %>% -log10(.)
       ) %>%
-      slice_max(pvalue_norm) %>%
+      slice_max(pvalue_norm, n = 1, with_ties = FALSE) %>%
       select(-c(pvalue, qvalue)) %>%
       rename(pvalue = pvalue_norm, qvalue = qvalue_norm)
   )

--- a/modules/CCBR/sort/bed/main.nf
+++ b/modules/CCBR/sort/bed/main.nf
@@ -1,0 +1,42 @@
+process SORT_BED {
+    tag { meta.id }
+    label 'process_single'
+
+    container 'nciccbr/ccbr_ubuntu_base_20.04:v5'
+
+    input:
+    tuple val(meta), path(bed)
+
+    output:
+    tuple val(meta), path("*.sorted.bed"), emit: bed
+    path "versions.yml"                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ' -k 1,1 -k2,2n '
+    def outfile = "${bed.baseName}.sorted.bed"
+    """
+    sort \\
+        ${args} \\
+        ${bed} > ${outfile}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        sort: \$(echo \$(sort --version | head -n 1 | sed 's/.* //'))
+    END_VERSIONS
+    """
+
+    stub:
+    def outfile = "${bed.baseName}.sorted.bed"
+    """
+    touch ${outfile}
+
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        sort: \$(echo \$(sort --version | head -n 1 | sed 's/.* //'))
+    END_VERSIONS
+    """
+}

--- a/modules/CCBR/sort/bed/meta.yml
+++ b/modules/CCBR/sort/bed/meta.yml
@@ -7,7 +7,7 @@ keywords:
   - bed
   - genomics
 tools:
-  - "GNU coreutils":
+  - "GNU_coreutils":
       description: "The GNU Core Utilities are the basic file, shell and text manipulation utilities of the GNU operating system. These are the core utilities which are expected to exist on every operating system."
       homepage: "https://www.gnu.org/software/coreutils/"
       licence: ["GPL-3.0"]

--- a/modules/CCBR/sort/bed/meta.yml
+++ b/modules/CCBR/sort/bed/meta.yml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
+name: "sort_bed"
+description: sort a bed file by chromosome then by start position
+keywords:
+  - sort
+  - bed
+  - genomics
+tools:
+  - "GNU coreutils":
+      description: "The GNU Core Utilities are the basic file, shell and text manipulation utilities of the GNU operating system. These are the core utilities which are expected to exist on every operating system."
+      homepage: "https://www.gnu.org/software/coreutils/"
+      licence: ["GPL-3.0"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+
+  - bed:
+      type: file
+      description: BED file, or any tab-delimited text file with at least two columns
+      pattern: "*.bed"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+
+  - bed:
+      type: file
+      description: input file sorted by first and second columns
+      pattern: "*.bed"
+
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@kelly-sovacool"
+maintainers:
+  - "@kelly-sovacool"

--- a/subworkflows/CCBR/consensus_peaks/main.nf
+++ b/subworkflows/CCBR/consensus_peaks/main.nf
@@ -31,14 +31,14 @@ workflow CONSENSUS_PEAKS {
             }
             .groupTuple()
         peaks_grouped | CAT_CAT
-        BEDTOOLS_SORT( CAT_CAT.out.file_out )
-        BEDTOOLS_MERGE(BEDTOOLS_SORT.out.sorted, ' -c 1,5,6,7,8,9 -o count,collapse,collapse,collapse,collapse,collapse ')
+        SORT_BED( CAT_CAT.out.file_out )
+        BEDTOOLS_MERGE(SORT_BED.out.bed, ' -c 1,5,6,7,8,9 -o count,collapse,collapse,collapse,collapse,collapse ')
         CUSTOM_FORMATMERGEDBED(BEDTOOLS_MERGE.out.bed)
         consensus_peaks = CUSTOM_FORMATMERGEDBED.out.bed
 
         ch_versions = ch_versions.mix(
             CAT_CAT.out.versions,
-            BEDTOOLS_SORT.out.versions,
+            SORT_BED.out.versions,
             BEDTOOLS_MERGE.out.versions,
             CUSTOM_FORMATMERGEDBED.out.versions
         )

--- a/subworkflows/CCBR/consensus_peaks/main.nf
+++ b/subworkflows/CCBR/consensus_peaks/main.nf
@@ -2,7 +2,7 @@ include { CAT_CAT        } from '../../../modules/CCBR/cat/cat/'
 include { BEDTOOLS_SORT  } from '../../../modules/CCBR/bedtools/sort/' // TODO use unix sort for better performance
 include { BEDTOOLS_MERGE } from '../../../modules/CCBR/bedtools/merge/'
 include { BEDOPS_BEDMAP  } from '../../../modules/CCBR/bedops/bedmap/'
-include { CUSTOM_COMBINEPEAKCOUNTS  } from '../../../modules/CCBR/custom/combinepeakcounts/'
+include { CUSTOM_FORMATMERGEDBED  } from '../../../modules/CCBR/custom/formatmergedbed/'
 include { CUSTOM_NORMALIZEPEAKS     } from '../../../modules/CCBR/custom/normalizepeaks/'
 
 workflow CONSENSUS_PEAKS {
@@ -19,6 +19,12 @@ workflow CONSENSUS_PEAKS {
 
         ch_versions = Channel.empty()
 
+        if (normalize) {
+            ch_peaks | CUSTOM_NORMALIZEPEAKS
+            ch_peaks = CUSTOM_NORMALIZEPEAKS.out.bed
+            ch_versions = ch_versions.mix(CUSTOM_NORMALIZEPEAKS.out.versions)
+        }
+
         peaks_grouped = ch_peaks
             .map{ meta, peak ->
                 [ [id: meta.group], peak ]
@@ -26,39 +32,15 @@ workflow CONSENSUS_PEAKS {
             .groupTuple()
         peaks_grouped | CAT_CAT
         BEDTOOLS_SORT( CAT_CAT.out.file_out, [] )
-        peaks_cat_sorted = BEDTOOLS_SORT.out.sorted
-        peaks_cat_sorted | BEDTOOLS_MERGE
-        ch_peaks.combine(BEDTOOLS_MERGE.out.bed) | BEDOPS_BEDMAP
-
-        counts_grouped = BEDOPS_BEDMAP.out.bed
-            .map { meta, bed ->
-                [ [id: meta.group], bed ]
-            }
-            .groupTuple()
-        counts_grouped | CUSTOM_COMBINEPEAKCOUNTS
-        consensus_peaks = CUSTOM_COMBINEPEAKCOUNTS.out.bed
-
-        if (normalize) {
-            ch_count_peak = CUSTOM_COMBINEPEAKCOUNTS.out.bed
-                .cross(peaks_cat_sorted)
-                .map{ it ->
-                    it.flatten()
-                }
-                .map{ meta1, count, meta2, peak ->
-                    assert meta1.id == meta2.id
-                    [ meta1, count, peak ]
-                }
-            ch_count_peak | CUSTOM_NORMALIZEPEAKS
-            consensus_peaks = CUSTOM_NORMALIZEPEAKS.out.bed
-            ch_versions = ch_versions.mix(CUSTOM_NORMALIZEPEAKS.out.versions)
-        }
+        BEDTOOLS_MERGE(BEDTOOLS_SORT.out.sorted, ' -c 1,5,6,7,8,9 -o count,collapse,collapse,collapse,collapse,collapse ')
+        CUSTOM_FORMATMERGEDBED(BEDTOOLS_MERGE.out.bed)
+        consensus_peaks = CUSTOM_FORMATMERGEDBED.out.bed
 
         ch_versions = ch_versions.mix(
             CAT_CAT.out.versions,
             BEDTOOLS_SORT.out.versions,
             BEDTOOLS_MERGE.out.versions,
-            BEDOPS_BEDMAP.out.versions,
-            CUSTOM_COMBINEPEAKCOUNTS.out.versions
+            CUSTOM_FORMATMERGEDBED.out.versions
         )
 
     emit:

--- a/subworkflows/CCBR/consensus_peaks/main.nf
+++ b/subworkflows/CCBR/consensus_peaks/main.nf
@@ -1,5 +1,5 @@
 include { CAT_CAT        } from '../../../modules/CCBR/cat/cat/'
-include { BEDTOOLS_SORT  } from '../../../modules/CCBR/bedtools/sort/' // TODO use unix sort for better performance
+include { SORT_BED  } from '../../../modules/CCBR/sort/bed'
 include { BEDTOOLS_MERGE } from '../../../modules/CCBR/bedtools/merge/'
 include { BEDOPS_BEDMAP  } from '../../../modules/CCBR/bedops/bedmap/'
 include { CUSTOM_FORMATMERGEDBED  } from '../../../modules/CCBR/custom/formatmergedbed/'
@@ -31,7 +31,7 @@ workflow CONSENSUS_PEAKS {
             }
             .groupTuple()
         peaks_grouped | CAT_CAT
-        BEDTOOLS_SORT( CAT_CAT.out.file_out, [] )
+        BEDTOOLS_SORT( CAT_CAT.out.file_out )
         BEDTOOLS_MERGE(BEDTOOLS_SORT.out.sorted, ' -c 1,5,6,7,8,9 -o count,collapse,collapse,collapse,collapse,collapse ')
         CUSTOM_FORMATMERGEDBED(BEDTOOLS_MERGE.out.bed)
         consensus_peaks = CUSTOM_FORMATMERGEDBED.out.bed

--- a/subworkflows/CCBR/consensus_peaks/main.nf
+++ b/subworkflows/CCBR/consensus_peaks/main.nf
@@ -1,7 +1,6 @@
 include { CAT_CAT        } from '../../../modules/CCBR/cat/cat/'
 include { SORT_BED  } from '../../../modules/CCBR/sort/bed'
 include { BEDTOOLS_MERGE } from '../../../modules/CCBR/bedtools/merge/'
-include { BEDOPS_BEDMAP  } from '../../../modules/CCBR/bedops/bedmap/'
 include { CUSTOM_FORMATMERGEDBED  } from '../../../modules/CCBR/custom/formatmergedbed/'
 include { CUSTOM_NORMALIZEPEAKS     } from '../../../modules/CCBR/custom/normalizepeaks/'
 

--- a/subworkflows/CCBR/consensus_peaks/meta.yml
+++ b/subworkflows/CCBR/consensus_peaks/meta.yml
@@ -11,7 +11,6 @@ components:
   - bedtools/merge
   - bedops/bedmap
   - cat/cat
-  - custom/combinepeakcounts
   - custom/normalizepeaks
   - custom/formatmergedbed
   - sort/bed

--- a/subworkflows/CCBR/consensus_peaks/meta.yml
+++ b/subworkflows/CCBR/consensus_peaks/meta.yml
@@ -9,7 +9,6 @@ keywords:
   - consensus
 components:
   - bedtools/merge
-  - bedops/bedmap
   - cat/cat
   - custom/normalizepeaks
   - custom/formatmergedbed

--- a/subworkflows/CCBR/consensus_peaks/meta.yml
+++ b/subworkflows/CCBR/consensus_peaks/meta.yml
@@ -8,12 +8,13 @@ keywords:
   - normalization
   - consensus
 components:
-  - bedtools/sort
   - bedtools/merge
   - bedops/bedmap
   - cat/cat
   - custom/combinepeakcounts
   - custom/normalizepeaks
+  - custom/formatmergedbed
+  - sort/bed
 input:
   - ch_peaks:
       type: file

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -74,6 +74,10 @@ samtools/filteraligned:
   - modules/CCBR/samtools/filteraligned/**
   - tests/modules/CCBR/samtools/filteraligned/**
 
+sort/bed:
+  - modules/CCBR/sort/bed/**
+  - tests/modules/CCBR/sort/bed/**
+
 subworkflows/consensus_peaks:
   - subworkflows/CCBR/consensus_peaks/**
   - tests/subworkflows/CCBR/consensus_peaks/**

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -50,6 +50,10 @@ custom/countfastq:
   - modules/CCBR/custom/countfastq/**
   - tests/modules/CCBR/custom/countfastq/**
 
+custom/formatmergedbed:
+  - modules/CCBR/custom/formatmergedbed/**
+  - tests/modules/CCBR/custom/formatmergedbed/**
+
 custom/normalizepeaks:
   - modules/CCBR/custom/normalizepeaks/**
   - tests/modules/CCBR/custom/normalizepeaks/**

--- a/tests/modules/CCBR/bedtools/merge/main.nf
+++ b/tests/modules/CCBR/bedtools/merge/main.nf
@@ -11,3 +11,11 @@ workflow test_bedtools_merge {
 
     BEDTOOLS_MERGE ( input, '' )
 }
+
+workflow test_bedtools_merge_args {
+    input = [ [ id:'test'],
+              file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+            ]
+
+    BEDTOOLS_MERGE ( input, ' -c 1,5 -o count,mean ' )
+}

--- a/tests/modules/CCBR/bedtools/merge/main.nf
+++ b/tests/modules/CCBR/bedtools/merge/main.nf
@@ -9,5 +9,5 @@ workflow test_bedtools_merge {
               file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
             ]
 
-    BEDTOOLS_MERGE ( input )
+    BEDTOOLS_MERGE ( input, '' )
 }

--- a/tests/modules/CCBR/bedtools/merge/test.yml
+++ b/tests/modules/CCBR/bedtools/merge/test.yml
@@ -1,8 +1,28 @@
-- name: bedtools merge
-  command: nextflow run ./tests/modules/CCBR/bedtools/merge -entry test_bedtools_merge -c ./tests/config/nextflow.config -c ./tests/modules/CCBR/bedtools/merge/nextflow.config
+- name: bedtools merge test_bedtools_merge
+  command: nextflow run ./tests/modules/CCBR/bedtools/merge -entry test_bedtools_merge -c ./tests/config/nextflow.config
   tags:
-    - bedtools
     - bedtools/merge
+    - bedtools
   files:
-    - path: ./output/bedtools/test_out.bed
+    - path: output/bedtools/test.merged.bed
       md5sum: 0cf6ed2b6f470cd44a247da74ca4fe4e
+    - path: output/bedtools/versions.yml
+
+- name: bedtools merge test_bedtools_merge_args
+  command: nextflow run ./tests/modules/CCBR/bedtools/merge -entry test_bedtools_merge_args -c ./tests/config/nextflow.config
+  tags:
+    - bedtools/merge
+    - bedtools
+  files:
+    - path: output/bedtools/test.merged.bed
+      md5sum: 609fc21107b6686ba2043d0095fefb0e
+    - path: output/bedtools/versions.yml
+
+- name: bedtools merge test_bedtools_merge stub
+  command: nextflow run ./tests/modules/CCBR/bedtools/merge -entry test_bedtools_merge -c ./tests/config/nextflow.config -stub
+  tags:
+    - bedtools/merge
+    - bedtools
+  files:
+    - path: output/bedtools/test.merged.bed
+    - path: output/bedtools/versions.yml

--- a/tests/modules/CCBR/bedtools/sort/test.yml
+++ b/tests/modules/CCBR/bedtools/sort/test.yml
@@ -1,5 +1,5 @@
 - name: bedtools sort test_bedtools_sort
-  command: nextflow run ./tests/modules/CCBR/bedtools/sort -entry test_bedtools_sort -c ./tests/config/nextflow.config -c ./tests/modules/CCBR/bedtools/sort/nextflow.config
+  command: nextflow run ./tests/modules/CCBR/bedtools/sort -entry test_bedtools_sort -c ./tests/config/nextflow.config
   tags:
     - bedtools
     - bedtools/sort
@@ -9,11 +9,20 @@
     - path: output/bedtools/versions.yml
 
 - name: bedtools sort test_bedtools_sort_with_genome
-  command: nextflow run ./tests/modules/CCBR/bedtools/sort -entry test_bedtools_sort_with_genome -c ./tests/config/nextflow.config -c ./tests/modules/CCBR/bedtools/sort/nextflow.config
+  command: nextflow run ./tests/modules/CCBR/bedtools/sort -entry test_bedtools_sort_with_genome -c ./tests/config/nextflow.config
   tags:
     - bedtools
     - bedtools/sort
   files:
     - path: output/bedtools/test_out.testtext
       md5sum: fe4053cf4de3aebbdfc3be2efb125a74
+    - path: output/bedtools/versions.yml
+
+- name: bedtools sort test_bedtools_sort stub
+  command: nextflow run ./tests/modules/CCBR/bedtools/sort -entry test_bedtools_sort -c ./tests/config/nextflow.config -stub
+  tags:
+    - bedtools
+    - bedtools/sort
+  files:
+    - path: output/bedtools/test_out.testtext
     - path: output/bedtools/versions.yml

--- a/tests/modules/CCBR/cat/cat/test.yml
+++ b/tests/modules/CCBR/cat/cat/test.yml
@@ -38,7 +38,7 @@
     - cat/cat
   files:
     - path: output/cat/cat.txt
-      md5sum: c439d3b60e7bc03e8802a451a0d9a5d9
+      md5sum: 1a983f97a01107efe42c8c3e7728b4c1
 
 - name: cat zipped unzipped stub
   command: nextflow run ./tests/modules/CCBR/cat/cat -entry test_cat_zipped_unzipped -c ./tests/config/nextflow.config -c ./tests/modules/CCBR/cat/cat/nextflow.config -stub-run

--- a/tests/modules/CCBR/custom/combinepeakcounts/main.nf
+++ b/tests/modules/CCBR/custom/combinepeakcounts/main.nf
@@ -23,7 +23,7 @@ workflow test_custom_combinepeakcounts {
         }
         .groupTuple() | CAT_CAT
     SORT_CAT(CAT_CAT.out.file_out, [])
-    SORT_CAT.out.sorted | BEDTOOLS_MERGE
+    BEDTOOLS_MERGE( SORT_CAT.out.sorted, '' )
 
     // map peaks to reference
     SORT_PEAK(ch_peaks, [])

--- a/tests/modules/CCBR/custom/combinepeakcounts/test.yml
+++ b/tests/modules/CCBR/custom/combinepeakcounts/test.yml
@@ -1,15 +1,15 @@
 - name: custom combinepeakcounts test_custom_combinepeakcounts
   command: nextflow run ./tests/modules/CCBR/custom/combinepeakcounts -entry test_custom_combinepeakcounts -c ./tests/config/nextflow.config
   tags:
-    - custom
     - custom/combinepeakcounts
+    - custom
   files:
     - path: output/bedops_bedmap/SPT5_T0_1_peaks.test.mapped.bed
       md5sum: a46e2f78e8534ecdc882fff22f0baa87
     - path: output/bedops_bedmap/SPT5_T0_2_peaks.test.mapped.bed
       md5sum: c58be7ebe1f63c1cdf9eef66a41e23c1
     - path: output/bedops_bedmap/versions.yml
-    - path: output/bedtools_merge/test.merged.bed
+    - path: output/bedtools_merge/test.sorted.merged.bed
       md5sum: d67c8c15b99b310ec5aa0ec363dcd147
     - path: output/bedtools_merge/versions.yml
     - path: output/cat_cat/test.broadPeak
@@ -30,13 +30,13 @@
 - name: custom combinepeakcounts test_custom_combinepeakcounts stub
   command: nextflow run ./tests/modules/CCBR/custom/combinepeakcounts -entry test_custom_combinepeakcounts -c ./tests/config/nextflow.config -stub
   tags:
-    - custom
     - custom/combinepeakcounts
+    - custom
   files:
     - path: output/bedops_bedmap/SPT5_T0_1_peaks.test.mapped.bed
     - path: output/bedops_bedmap/SPT5_T0_2_peaks.test.mapped.bed
     - path: output/bedops_bedmap/versions.yml
-    - path: output/bedtools_merge/test.merged.bed
+    - path: output/bedtools_merge/test.sorted.merged.bed
     - path: output/bedtools_merge/versions.yml
     - path: output/cat_cat/test.broadPeak
     - path: output/cat_cat/versions.yml

--- a/tests/modules/CCBR/custom/formatmergedbed/main.nf
+++ b/tests/modules/CCBR/custom/formatmergedbed/main.nf
@@ -1,0 +1,28 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { CAT_CAT                    } from '../../../../../modules/CCBR/cat/cat/main.nf'
+include { BEDTOOLS_SORT  } from '../../../../../modules/CCBR/bedtools/sort/main.nf'
+include { BEDTOOLS_MERGE             } from '../../../../../modules/CCBR/bedtools/merge/main.nf'
+include { CUSTOM_FORMATMERGEDBED } from '../../../../../modules/CCBR/custom/formatmergedbed/main.nf'
+
+workflow test_custom_formatmergedbed {
+
+    ch_peaks = Channel.fromPath([file(params.test_data.macs.broad.peaks_T0_1, checkIfExists: true),
+                                 file(params.test_data.macs.broad.peaks_T0_2, checkIfExists: true)])
+        .map { peak ->
+            [ [id: peak.baseName, group: 'macs_broad'], peak ]
+        }
+
+    peaks_grouped = ch_peaks
+        .map{ meta, peak ->
+            [ [id: meta.group], peak ]
+        }
+        .groupTuple()
+    peaks_grouped | CAT_CAT
+    BEDTOOLS_SORT(CAT_CAT.out.file_out, [])
+    BEDTOOLS_MERGE( BEDTOOLS_SORT.out.sorted, ' -c 1,5,6,7,8,9 -o count,collapse,collapse,collapse,collapse,collapse ' )
+
+    CUSTOM_FORMATMERGEDBED ( BEDTOOLS_MERGE.out.bed )
+}

--- a/tests/modules/CCBR/custom/formatmergedbed/main.nf
+++ b/tests/modules/CCBR/custom/formatmergedbed/main.nf
@@ -3,7 +3,7 @@
 nextflow.enable.dsl = 2
 
 include { CAT_CAT                    } from '../../../../../modules/CCBR/cat/cat/main.nf'
-include { BEDTOOLS_SORT  } from '../../../../../modules/CCBR/bedtools/sort/main.nf'
+include { SORT_BED  } from '../../../../../modules/CCBR/sort/bed/main.nf'
 include { BEDTOOLS_MERGE             } from '../../../../../modules/CCBR/bedtools/merge/main.nf'
 include { CUSTOM_FORMATMERGEDBED } from '../../../../../modules/CCBR/custom/formatmergedbed/main.nf'
 
@@ -21,8 +21,8 @@ workflow test_custom_formatmergedbed {
         }
         .groupTuple()
     peaks_grouped | CAT_CAT
-    BEDTOOLS_SORT(CAT_CAT.out.file_out, [])
-    BEDTOOLS_MERGE( BEDTOOLS_SORT.out.sorted, ' -c 1,5,6,7,8,9 -o count,collapse,collapse,collapse,collapse,collapse ' )
+    SORT_BED(CAT_CAT.out.file_out)
+    BEDTOOLS_MERGE( SORT_BED.out.bed, ' -c 1,5,6,7,8,9 -o count,collapse,collapse,collapse,collapse,collapse ' )
 
     CUSTOM_FORMATMERGEDBED ( BEDTOOLS_MERGE.out.bed )
 }

--- a/tests/modules/CCBR/custom/formatmergedbed/nextflow.config
+++ b/tests/modules/CCBR/custom/formatmergedbed/nextflow.config
@@ -1,0 +1,7 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+}
+
+includeConfig '../../../../config/test_data_CCBR.config'

--- a/tests/modules/CCBR/custom/formatmergedbed/test.yml
+++ b/tests/modules/CCBR/custom/formatmergedbed/test.yml
@@ -4,10 +4,8 @@
     - custom
     - custom/formatmergedbed
   files:
-    - path: output/bedtools/macs_broad.sorted.broadPeak
-      md5sum: b412285368f1698634177087e7ea4103
     - path: output/bedtools/macs_broad.sorted.merged.bed
-      md5sum: 767cd0823be78daedc7a6c1b570ee496
+      md5sum: 04ce00285f1960a006f13e5f90482ea1
     - path: output/bedtools/versions.yml
     - path: output/cat/macs_broad.broadPeak
       md5sum: c5d73e727a10d2a32b139efcdd369f59
@@ -15,6 +13,9 @@
     - path: output/custom/macs_broad.sorted.merged.consensus.bed
       md5sum: 4266c4e4fed0ceaaaf97ecd0a6baaec4
     - path: output/custom/versions.yml
+    - path: output/sort/macs_broad.sorted.bed
+      md5sum: 7ea9a8ca2c6ad93dc7e7714016789559
+    - path: output/sort/versions.yml
 
 - name: custom formatmergedbed test_custom_formatmergedbed stub
   command: nextflow run ./tests/modules/CCBR/custom/formatmergedbed -entry test_custom_formatmergedbed -c ./tests/config/nextflow.config -stub
@@ -22,10 +23,11 @@
     - custom
     - custom/formatmergedbed
   files:
-    - path: output/bedtools/macs_broad.sorted.broadPeak
     - path: output/bedtools/macs_broad.sorted.merged.bed
     - path: output/bedtools/versions.yml
     - path: output/cat/macs_broad.broadPeak
     - path: output/cat/versions.yml
     - path: output/custom/macs_broad.sorted.merged.consensus.bed
     - path: output/custom/versions.yml
+    - path: output/sort/macs_broad.sorted.bed
+    - path: output/sort/versions.yml

--- a/tests/modules/CCBR/custom/formatmergedbed/test.yml
+++ b/tests/modules/CCBR/custom/formatmergedbed/test.yml
@@ -1,0 +1,31 @@
+- name: custom formatmergedbed test_custom_formatmergedbed
+  command: nextflow run ./tests/modules/CCBR/custom/formatmergedbed -entry test_custom_formatmergedbed -c ./tests/config/nextflow.config
+  tags:
+    - custom
+    - custom/formatmergedbed
+  files:
+    - path: output/bedtools/macs_broad.sorted.broadPeak
+      md5sum: b412285368f1698634177087e7ea4103
+    - path: output/bedtools/macs_broad.sorted.merged.bed
+      md5sum: 767cd0823be78daedc7a6c1b570ee496
+    - path: output/bedtools/versions.yml
+    - path: output/cat/macs_broad.broadPeak
+      md5sum: c5d73e727a10d2a32b139efcdd369f59
+    - path: output/cat/versions.yml
+    - path: output/custom/macs_broad.sorted.merged.consensus.bed
+      md5sum: 4266c4e4fed0ceaaaf97ecd0a6baaec4
+    - path: output/custom/versions.yml
+
+- name: custom formatmergedbed test_custom_formatmergedbed stub
+  command: nextflow run ./tests/modules/CCBR/custom/formatmergedbed -entry test_custom_formatmergedbed -c ./tests/config/nextflow.config -stub
+  tags:
+    - custom
+    - custom/formatmergedbed
+  files:
+    - path: output/bedtools/macs_broad.sorted.broadPeak
+    - path: output/bedtools/macs_broad.sorted.merged.bed
+    - path: output/bedtools/versions.yml
+    - path: output/cat/macs_broad.broadPeak
+    - path: output/cat/versions.yml
+    - path: output/custom/macs_broad.sorted.merged.consensus.bed
+    - path: output/custom/versions.yml

--- a/tests/modules/CCBR/custom/normalizepeaks/main.nf
+++ b/tests/modules/CCBR/custom/normalizepeaks/main.nf
@@ -17,35 +17,5 @@ workflow test_custom_normalizepeaks {
         .map { peak ->
             [ [id: peak.baseName, group: 'macs_broad'], peak ]
         }
-    // prepare reference
-    peaks_grouped = ch_peaks
-            .map{ meta, peak ->
-                [ [id: meta.group], peak ]
-            }
-            .groupTuple()
-        peaks_grouped | CAT_CAT
-    SORT_CAT(CAT_CAT.out.file_out, [])
-    SORT_CAT.out.sorted | BEDTOOLS_MERGE
-
-    // map peaks to reference
-    SORT_PEAK(ch_peaks, [])
-    SORT_PEAK.out.sorted.combine(BEDTOOLS_MERGE.out.bed) | BEDOPS_BEDMAP
-
-    counts_grouped = BEDOPS_BEDMAP.out.bed
-            .map { meta, bed ->
-                [ [id: meta.group], bed ]
-            }
-            .groupTuple()
-    counts_grouped | CUSTOM_COMBINEPEAKCOUNTS
-
-    ch_count_peak = CUSTOM_COMBINEPEAKCOUNTS.out.bed
-        .cross(SORT_CAT.out.sorted)
-        .map{ it ->
-            it.flatten()
-        }
-        .map{ meta1, count, meta2, peak ->
-            assert meta1.id == meta2.id
-            [ meta1, count, peak ]
-        }
-    ch_count_peak | CUSTOM_NORMALIZEPEAKS
+    ch_peaks | CUSTOM_NORMALIZEPEAKS
 }

--- a/tests/modules/CCBR/custom/normalizepeaks/main.nf
+++ b/tests/modules/CCBR/custom/normalizepeaks/main.nf
@@ -2,12 +2,6 @@
 
 nextflow.enable.dsl = 2
 
-include { CAT_CAT                    } from '../../../../../modules/CCBR/cat/cat/main.nf'
-include { BEDOPS_BEDMAP              } from '../../../../../modules/CCBR/bedops/bedmap/main.nf'
-include { BEDTOOLS_SORT as SORT_CAT
-          BEDTOOLS_SORT as SORT_PEAK } from '../../../../../modules/CCBR/bedtools/sort/main.nf'
-include { BEDTOOLS_MERGE             } from '../../../../../modules/CCBR/bedtools/merge/main.nf'
-include { CUSTOM_COMBINEPEAKCOUNTS   } from '../../../../../modules/CCBR/custom/combinepeakcounts/main.nf'
 include { CUSTOM_NORMALIZEPEAKS      } from '../../../../../modules/CCBR/custom/normalizepeaks/main.nf'
 
 workflow test_custom_normalizepeaks {

--- a/tests/modules/CCBR/custom/normalizepeaks/test.yml
+++ b/tests/modules/CCBR/custom/normalizepeaks/test.yml
@@ -1,54 +1,21 @@
 - name: custom normalizepeaks test_custom_normalizepeaks
   command: nextflow run ./tests/modules/CCBR/custom/normalizepeaks -entry test_custom_normalizepeaks -c ./tests/config/nextflow.config
   tags:
-    - custom/normalizepeaks
     - custom
+    - custom/normalizepeaks
   files:
-    - path: output/bedops_bedmap/SPT5_T0_1_peaks.macs_broad.mapped.bed
-      md5sum: a46e2f78e8534ecdc882fff22f0baa87
-    - path: output/bedops_bedmap/SPT5_T0_2_peaks.macs_broad.mapped.bed
-      md5sum: c58be7ebe1f63c1cdf9eef66a41e23c1
-    - path: output/bedops_bedmap/versions.yml
-    - path: output/bedtools_merge/macs_broad.merged.bed
-      md5sum: d67c8c15b99b310ec5aa0ec363dcd147
-    - path: output/bedtools_merge/versions.yml
-    - path: output/cat_cat/macs_broad.broadPeak
-      md5sum: c5d73e727a10d2a32b139efcdd369f59
-    - path: output/cat_cat/versions.yml
-    - path: output/custom_combinepeakcounts/macs_broad.consensus.bed
-      md5sum: 600f5c2dfeae440ada8c412c153a677e
-    - path: output/custom_combinepeakcounts/versions.yml
-    - path: output/custom_normalizepeaks/macs_broad.consensus.norm.bed
-      md5sum: 91162a273adbde73bec3dfd0d87c16fd
+    - path: output/custom_normalizepeaks/SPT5_T0_1_peaks.norm.bed
+      md5sum: 7129eb9aa8927da730105395afab08b7
+    - path: output/custom_normalizepeaks/SPT5_T0_2_peaks.norm.bed
+      md5sum: b0be5d27ea40294c99ba48275dd0e54c
     - path: output/custom_normalizepeaks/versions.yml
-    - path: output/sort_cat/macs_broad.sorted.broadPeak
-      md5sum: b412285368f1698634177087e7ea4103
-    - path: output/sort_cat/versions.yml
-    - path: output/sort_peak/SPT5_T0_1_peaks.sorted.broadPeak
-      md5sum: 03b87e9021f85db1c8e07f5c0b4d7347
-    - path: output/sort_peak/SPT5_T0_2_peaks.sorted.broadPeak
-      md5sum: d3216918f24ced4b76b8eed6e38aa5c6
-    - path: output/sort_peak/versions.yml
 
 - name: custom normalizepeaks test_custom_normalizepeaks stub
   command: nextflow run ./tests/modules/CCBR/custom/normalizepeaks -entry test_custom_normalizepeaks -c ./tests/config/nextflow.config -stub
   tags:
-    - custom/normalizepeaks
     - custom
+    - custom/normalizepeaks
   files:
-    - path: output/bedops_bedmap/SPT5_T0_1_peaks.macs_broad.mapped.bed
-    - path: output/bedops_bedmap/SPT5_T0_2_peaks.macs_broad.mapped.bed
-    - path: output/bedops_bedmap/versions.yml
-    - path: output/bedtools_merge/macs_broad.merged.bed
-    - path: output/bedtools_merge/versions.yml
-    - path: output/cat_cat/macs_broad.broadPeak
-    - path: output/cat_cat/versions.yml
-    - path: output/custom_combinepeakcounts/macs_broad.consensus.bed
-    - path: output/custom_combinepeakcounts/versions.yml
-    - path: output/custom_normalizepeaks/macs_broad.consensus.norm.bed
+    - path: output/custom_normalizepeaks/SPT5_T0_1_peaks.norm.bed
+    - path: output/custom_normalizepeaks/SPT5_T0_2_peaks.norm.bed
     - path: output/custom_normalizepeaks/versions.yml
-    - path: output/sort_cat/macs_broad.sorted.broadPeak
-    - path: output/sort_cat/versions.yml
-    - path: output/sort_peak/SPT5_T0_1_peaks.sorted.broadPeak
-    - path: output/sort_peak/SPT5_T0_2_peaks.sorted.broadPeak
-    - path: output/sort_peak/versions.yml

--- a/tests/modules/CCBR/custom/normalizepeaks/test.yml
+++ b/tests/modules/CCBR/custom/normalizepeaks/test.yml
@@ -1,21 +1,21 @@
 - name: custom normalizepeaks test_custom_normalizepeaks
   command: nextflow run ./tests/modules/CCBR/custom/normalizepeaks -entry test_custom_normalizepeaks -c ./tests/config/nextflow.config
   tags:
-    - custom
     - custom/normalizepeaks
+    - custom
   files:
-    - path: output/custom_normalizepeaks/SPT5_T0_1_peaks.norm.bed
+    - path: output/custom_normalizepeaks/SPT5_T0_1_peaks.broadPeak.norm.bed
       md5sum: 7129eb9aa8927da730105395afab08b7
-    - path: output/custom_normalizepeaks/SPT5_T0_2_peaks.norm.bed
+    - path: output/custom_normalizepeaks/SPT5_T0_2_peaks.broadPeak.norm.bed
       md5sum: b0be5d27ea40294c99ba48275dd0e54c
     - path: output/custom_normalizepeaks/versions.yml
 
 - name: custom normalizepeaks test_custom_normalizepeaks stub
   command: nextflow run ./tests/modules/CCBR/custom/normalizepeaks -entry test_custom_normalizepeaks -c ./tests/config/nextflow.config -stub
   tags:
-    - custom
     - custom/normalizepeaks
+    - custom
   files:
-    - path: output/custom_normalizepeaks/SPT5_T0_1_peaks.norm.bed
-    - path: output/custom_normalizepeaks/SPT5_T0_2_peaks.norm.bed
+    - path: output/custom_normalizepeaks/SPT5_T0_1_peaks.broadPeak.norm.bed
+    - path: output/custom_normalizepeaks/SPT5_T0_2_peaks.broadPeak.norm.bed
     - path: output/custom_normalizepeaks/versions.yml

--- a/tests/modules/CCBR/sort/bed/main.nf
+++ b/tests/modules/CCBR/sort/bed/main.nf
@@ -1,0 +1,14 @@
+nextflow.enable.dsl = 2
+
+include { SORT_BED } from '../../../../../modules/CCBR/sort/bed'
+
+
+workflow test_sort_bed {
+
+    input = Channel.fromPath([file(params.test_data.macs.broad.peaks_T0_1, checkIfExists: true),
+                              file(params.test_data.macs.broad.peaks_T0_2, checkIfExists: true)])
+        .map { peak ->
+            [ [id: peak.baseName, group: 'macs_broad'], peak ]
+        }
+    SORT_BED(input)
+}

--- a/tests/modules/CCBR/sort/bed/nextflow.config
+++ b/tests/modules/CCBR/sort/bed/nextflow.config
@@ -1,0 +1,7 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+}
+
+includeConfig '../../../../config/test_data_CCBR.config'

--- a/tests/modules/CCBR/sort/bed/test.yml
+++ b/tests/modules/CCBR/sort/bed/test.yml
@@ -1,0 +1,21 @@
+- name: sort bed test_sort_bed
+  command: nextflow run ./tests/modules/CCBR/sort/bed -entry test_sort_bed -c ./tests/config/nextflow.config
+  tags:
+    - sort/bed
+    - sort
+  files:
+    - path: output/sort/SPT5_T0_1_peaks.sorted.bed
+      md5sum: 03b87e9021f85db1c8e07f5c0b4d7347
+    - path: output/sort/SPT5_T0_2_peaks.sorted.bed
+      md5sum: d3216918f24ced4b76b8eed6e38aa5c6
+    - path: output/sort/versions.yml
+
+- name: sort bed test_sort_bed stub
+  command: nextflow run ./tests/modules/CCBR/sort/bed -entry test_sort_bed -c ./tests/config/nextflow.config -stub
+  tags:
+    - sort/bed
+    - sort
+  files:
+    - path: output/sort/SPT5_T0_1_peaks.sorted.bed
+    - path: output/sort/SPT5_T0_2_peaks.sorted.bed
+    - path: output/sort/versions.yml

--- a/tests/subworkflows/CCBR/consensus_peaks/main.nf
+++ b/tests/subworkflows/CCBR/consensus_peaks/main.nf
@@ -2,7 +2,6 @@
 
 nextflow.enable.dsl = 2
 
-include { SORT_BED  } from '../../../modules/CCBR/sort/bed'
 include { CONSENSUS_PEAKS } from '../../../../subworkflows/CCBR/consensus_peaks'
 
 
@@ -13,10 +12,7 @@ workflow test_consensus_peaks_broad {
         .map { peak ->
             [ [id: peak.baseName, group: 'macs_broad'], peak ]
         }
-    SORT_BED(input)
-    peaks = SORT_BED.out.bed
-
-    CONSENSUS_PEAKS( peaks, false )
+    CONSENSUS_PEAKS( input, false )
 }
 
 workflow test_consensus_peaks_mix_norm {
@@ -32,8 +28,6 @@ workflow test_consensus_peaks_mix_norm {
             [ [id: peak.baseName, group: 'macs_narrow'], peak ]
         }
     input = broad.mix(narrow)
-    SORT_BED(input)
-    peaks = SORT_BED.out.bed
 
-    CONSENSUS_PEAKS( peaks, true )
+    CONSENSUS_PEAKS( input, true )
 }

--- a/tests/subworkflows/CCBR/consensus_peaks/main.nf
+++ b/tests/subworkflows/CCBR/consensus_peaks/main.nf
@@ -2,7 +2,7 @@
 
 nextflow.enable.dsl = 2
 
-include { BEDTOOLS_SORT  } from '../../../modules/CCBR/bedtools/sort/'
+include { SORT_BED  } from '../../../modules/CCBR/sort/bed'
 include { CONSENSUS_PEAKS } from '../../../../subworkflows/CCBR/consensus_peaks'
 
 
@@ -13,8 +13,8 @@ workflow test_consensus_peaks_broad {
         .map { peak ->
             [ [id: peak.baseName, group: 'macs_broad'], peak ]
         }
-    BEDTOOLS_SORT(input, [])
-    peaks = BEDTOOLS_SORT.out.sorted
+    SORT_BED(input)
+    peaks = SORT_BED.out.bed
 
     CONSENSUS_PEAKS( peaks, false )
 }
@@ -32,8 +32,8 @@ workflow test_consensus_peaks_mix_norm {
             [ [id: peak.baseName, group: 'macs_narrow'], peak ]
         }
     input = broad.mix(narrow)
-    BEDTOOLS_SORT(input, [])
-    peaks = BEDTOOLS_SORT.out.sorted
+    SORT_BED(input)
+    peaks = SORT_BED.out.bed
 
     CONSENSUS_PEAKS( peaks, true )
 }

--- a/tests/subworkflows/CCBR/consensus_peaks/test.yml
+++ b/tests/subworkflows/CCBR/consensus_peaks/test.yml
@@ -5,42 +5,24 @@
     - bedops/bedmap
     - bedtools
     - bedtools/merge
-    - bedtools/sort
     - cat
     - cat/cat
     - custom
-    - custom/combinepeakcounts
+    - custom/formatmergedbed
     - custom/normalizepeaks
+    - sort
+    - sort/bed
     - subworkflows
     - subworkflows/consensus_peaks
   files:
-    - path: output/custom_combinepeakcounts/macs_broad.consensus.bed
-      md5sum: 600f5c2dfeae440ada8c412c153a677e
-
-- name: consensus_peaks test_consensus_peaks_broad stub
-  command: nextflow run ./tests/subworkflows/CCBR/consensus_peaks -entry test_consensus_peaks_broad -c ./tests/config/nextflow.config -stub
-  tags:
-    - bedops
-    - bedops/bedmap
-    - bedtools
-    - bedtools/merge
-    - bedtools/sort
-    - cat
-    - cat/cat
-    - custom
-    - custom/combinepeakcounts
-    - custom/normalizepeaks
-    - subworkflows
-    - subworkflows/consensus_peaks
-  files:
-    - path: output/bedops_bedmap/SPT5_T0_1_peaks.macs_broad.mapped.bed
-    - path: output/bedops_bedmap/SPT5_T0_2_peaks.macs_broad.mapped.bed
-    - path: output/bedtools_merge/macs_broad.merged.bed
-    - path: output/bedtools_sort/SPT5_T0_1_peaks.sorted.broadPeak
-    - path: output/bedtools_sort/SPT5_T0_2_peaks.sorted.broadPeak
-    - path: output/bedtools_sort/macs_broad.sorted.broadPeak
+    - path: output/bedtools_merge/macs_broad.sorted.merged.bed
+      md5sum: 04ce00285f1960a006f13e5f90482ea1
     - path: output/cat_cat/macs_broad.broadPeak
-    - path: output/custom_combinepeakcounts/macs_broad.consensus.bed
+      md5sum: c5d73e727a10d2a32b139efcdd369f59
+    - path: output/custom_formatmergedbed/macs_broad.sorted.merged.consensus.bed
+      md5sum: 4266c4e4fed0ceaaaf97ecd0a6baaec4
+    - path: output/sort_bed/macs_broad.sorted.bed
+      md5sum: 7ea9a8ca2c6ad93dc7e7714016789559
 
 - name: consensus_peaks test_consensus_peaks_mix_norm
   command: nextflow run ./tests/subworkflows/CCBR/consensus_peaks -entry test_consensus_peaks_mix_norm -c ./tests/config/nextflow.config
@@ -49,16 +31,59 @@
     - bedops/bedmap
     - bedtools
     - bedtools/merge
-    - bedtools/sort
     - cat
     - cat/cat
     - custom
-    - custom/combinepeakcounts
+    - custom/formatmergedbed
     - custom/normalizepeaks
+    - sort
+    - sort/bed
     - subworkflows
     - subworkflows/consensus_peaks
   files:
-    - path: output/custom_normalizepeaks/macs_broad.consensus.norm.bed
-      md5sum: 9b133bf0d129a51491c9d722a7d577c0
-    - path: output/custom_normalizepeaks/macs_narrow.consensus.norm.bed
-      md5sum: 29d222c145ef196b2cc11b304c3ed2ed
+    - path: output/bedtools_merge/macs_broad.sorted.merged.bed
+      md5sum: 91dccf5c4f870193980bd298aa03864c
+    - path: output/bedtools_merge/macs_narrow.sorted.merged.bed
+      md5sum: 51d897e9f46241f7dadfd5bacd023660
+    - path: output/cat_cat/macs_broad.bed
+      md5sum: 1789beed3cb0688990ecca83344a8584
+    - path: output/cat_cat/macs_narrow.bed
+      md5sum: 063aaba2588582642cab5d511b48482c
+    - path: output/custom_formatmergedbed/macs_broad.sorted.merged.consensus.bed
+      md5sum: 7129eb9aa8927da730105395afab08b7
+    - path: output/custom_formatmergedbed/macs_narrow.sorted.merged.consensus.bed
+      md5sum: 2be28874a8902c61b82db0fecea29dd0
+    - path: output/custom_normalizepeaks/SPT5_T0_1_peaks.broadPeak.norm.bed
+      md5sum: 7129eb9aa8927da730105395afab08b7
+    - path: output/custom_normalizepeaks/SPT5_T0_1_peaks.narrowPeak.norm.bed
+      md5sum: 3a12d0a9387d254273bbeb805ff68bce
+    - path: output/custom_normalizepeaks/SPT5_T0_2_peaks.broadPeak.norm.bed
+      md5sum: b0be5d27ea40294c99ba48275dd0e54c
+    - path: output/custom_normalizepeaks/SPT5_T0_2_peaks.narrowPeak.norm.bed
+      md5sum: e09e72701b3e85583ba505cdc495e64e
+    - path: output/sort_bed/macs_broad.sorted.bed
+      md5sum: 1789beed3cb0688990ecca83344a8584
+    - path: output/sort_bed/macs_narrow.sorted.bed
+      md5sum: 063aaba2588582642cab5d511b48482c
+
+- name: consensus_peaks test_consensus_peaks_broad stub
+  command: nextflow run ./tests/subworkflows/CCBR/consensus_peaks -entry test_consensus_peaks_broad -c ./tests/config/nextflow.config -stub
+  tags:
+    - bedops
+    - bedops/bedmap
+    - bedtools
+    - bedtools/merge
+    - cat
+    - cat/cat
+    - custom
+    - custom/formatmergedbed
+    - custom/normalizepeaks
+    - sort
+    - sort/bed
+    - subworkflows
+    - subworkflows/consensus_peaks
+  files:
+    - path: output/bedtools_merge/macs_broad.sorted.merged.bed
+    - path: output/cat_cat/macs_broad.broadPeak
+    - path: output/custom_formatmergedbed/macs_broad.sorted.merged.consensus.bed
+    - path: output/sort_bed/macs_broad.sorted.bed


### PR DESCRIPTION
## Changes

- new process `formatmergedbed` to take the output from calling `bedtools merge -c 1,5,6,7,8,9 -o count,collapse,collapse,collapse,collapse,collapse` on concatenated peak files and format it as a narrow peak file.
  - For each consensus peak, the score/p-value/q-value etc. is kept for the peak with the highest -log10(p-value).
- Peak p-values are normalized prior to bedtools merge.
- Bedtools merge now accepts optional CLI args as a second input channel.
- Now use GNU sort instead of bedtools sort -- more efficient per bedtools docs.
 
## Issues

Related to CCBR/CHAMPAGNE#151

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
