### PR TITLE
refactor: better final output dir for consensus peaks

### DIFF
--- a/subworkflows/CCBR/consensus_peaks/main.nf
+++ b/subworkflows/CCBR/consensus_peaks/main.nf
@@ -1,7 +1,7 @@
 include { CAT_CAT        } from '../../../modules/CCBR/cat/cat/'
 include { SORT_BED  } from '../../../modules/CCBR/sort/bed'
 include { BEDTOOLS_MERGE } from '../../../modules/CCBR/bedtools/merge/'
-include { CUSTOM_FORMATMERGEDBED  } from '../../../modules/CCBR/custom/formatmergedbed/'
+include { CUSTOM_FORMATMERGEDBED as CONSENSUS_PEAKS_OUT  } from '../../../modules/CCBR/custom/formatmergedbed/'
 include { CUSTOM_NORMALIZEPEAKS     } from '../../../modules/CCBR/custom/normalizepeaks/'
 
 workflow CONSENSUS_PEAKS {
@@ -32,14 +32,14 @@ workflow CONSENSUS_PEAKS {
         peaks_grouped | CAT_CAT
         SORT_BED( CAT_CAT.out.file_out )
         BEDTOOLS_MERGE(SORT_BED.out.bed, ' -c 1,5,6,7,8,9 -o count,collapse,collapse,collapse,collapse,collapse ')
-        CUSTOM_FORMATMERGEDBED(BEDTOOLS_MERGE.out.bed)
-        consensus_peaks = CUSTOM_FORMATMERGEDBED.out.bed
+        CONSENSUS_PEAKS_OUT(BEDTOOLS_MERGE.out.bed)
+        consensus_peaks = CONSENSUS_PEAKS_OUT.out.bed
 
         ch_versions = ch_versions.mix(
             CAT_CAT.out.versions,
             SORT_BED.out.versions,
             BEDTOOLS_MERGE.out.versions,
-            CUSTOM_FORMATMERGEDBED.out.versions
+            CONSENSUS_PEAKS_OUT.out.versions
         )
 
     emit:

--- a/tests/subworkflows/CCBR/consensus_peaks/test.yml
+++ b/tests/subworkflows/CCBR/consensus_peaks/test.yml
@@ -17,7 +17,7 @@
       md5sum: 04ce00285f1960a006f13e5f90482ea1
     - path: output/cat_cat/macs_broad.broadPeak
       md5sum: c5d73e727a10d2a32b139efcdd369f59
-    - path: output/custom_formatmergedbed/macs_broad.sorted.merged.consensus.bed
+    - path: output/consensus_peaks_out/macs_broad.sorted.merged.consensus.bed
       md5sum: 4266c4e4fed0ceaaaf97ecd0a6baaec4
     - path: output/sort_bed/macs_broad.sorted.bed
       md5sum: 7ea9a8ca2c6ad93dc7e7714016789559
@@ -45,9 +45,9 @@
       md5sum: 64bdb72657a26b8bc963f9bd51f39565
     - path: output/cat_cat/macs_narrow.bed
       md5sum: 3974447bc99fc4930b56e171e545bc14
-    - path: output/custom_formatmergedbed/macs_broad.sorted.merged.consensus.bed
+    - path: output/consensus_peaks_out/macs_broad.sorted.merged.consensus.bed
       md5sum: 4f4d67389a8e327f21c0fd6d0d482780
-    - path: output/custom_formatmergedbed/macs_narrow.sorted.merged.consensus.bed
+    - path: output/consensus_peaks_out/macs_narrow.sorted.merged.consensus.bed
       md5sum: 51fee8455d9357b659d7c463c26e8158
     - path: output/custom_normalizepeaks/SPT5_T0_1_peaks.broadPeak.norm.bed
       md5sum: b330f110355268468fd775945de0e0d3
@@ -79,5 +79,5 @@
   files:
     - path: output/bedtools_merge/macs_broad.sorted.merged.bed
     - path: output/cat_cat/macs_broad.broadPeak
-    - path: output/custom_formatmergedbed/macs_broad.sorted.merged.consensus.bed
+    - path: output/consensus_peaks_out/macs_broad.sorted.merged.consensus.bed
     - path: output/sort_bed/macs_broad.sorted.bed


### PR DESCRIPTION
## Changes

Consensus peak files were in `CUSTOM_FORMATMERGEDBED`, which is not an intuitive place for users to find them. They're now in `CONSENSUS_PEAKS_OUT`.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [ ] Write unit tests for any new features, bug fixes, or other code changes.
- [ ] Update docs if there are any API changes.
- [ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
