### PR TITLE
ci: update runners to use ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
   nf-core-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: nf-core-lint
     needs: [pytest-changes]
     if: needs.pytest-changes.outputs.modules != '[]'
@@ -103,7 +103,7 @@ jobs:
         if: ${{ startsWith(matrix.tags, 'subworkflows/') }}
 
   pytest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: pytest
     needs: [pytest-changes]
     if: needs.pytest-changes.outputs.modules != '[]'
@@ -215,7 +215,7 @@ jobs:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
   nf-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: nf-test
     needs: [nf-test-changes]
     if: needs.nf-test-changes.outputs.modules != '[]'


### PR DESCRIPTION

## Changes

gh is deprecating ubuntu-20.04

## Issues

<!--
Reference any issues related to this PR.
If this PR fixes any issues, [use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
